### PR TITLE
FIXED: Incorrect DependencyInjection declaration

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,9 +11,7 @@
             <argument>%hashids.min_hash_length%</argument>
             <argument>%hashids.alphabet%</argument>
         </service>
-    </services>
 
-    <services>
         <service id="hashids.converter"
                  class="Roukmoute\HashidsBundle\ParamConverter\HashidsParamConverter"
         >


### PR DESCRIPTION
I got the following error after installing this bundle and traced it down to this file. Hereby sending a PR to fix it. 

`[ERROR 1871] Element '{http://symfony.com/schema/dic/services}services': This element is not expected. Expected is ( ##other{http://symfony.com/schema/dic/services}* ).`