### PR TITLE
Use encode / decode methods in twig template

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,5 +162,12 @@ public function getAction(User $user)
 As you can see, the autowiring feature reduces the amount of 
 configuration required to define a hashid.
 
+# Twig Extension
+## Usage
+```twig
+{{ path('users.show', {'hashid': user.id | hashids_encode }) }}
+{{ app.request.query.get('hashid') | hashids_decode }}
+```
+
 [1]: https://github.com/ivanakimov/hashids.php
 [2]: http://hashids.org/php/

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,5 +20,10 @@
             <argument>%hashids.autowire%</argument>
             <tag name="request.param_converter" priority="1" converter="hashids.converter" />
         </service>
+
+        <service id="hashids.twig.extension" class="Roukmoute\HashidsBundle\Twig\HashidsExtension">
+            <argument type="service" id="hashids" />
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Twig/HashidsExtension.php
+++ b/src/Twig/HashidsExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Roukmoute\HashidsBundle\Twig;
+
+use Roukmoute\HashidsBundle\Hashids;
+
+class HashidsExtension extends \Twig_Extension
+{
+    /**
+     * @var \Hashids\Hashids;
+     */
+    private $hashids;
+
+    public function __construct(Hashids $hashids)
+    {
+        $this->hashids = $hashids;
+    }
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('hashids_encode', [$this, 'encode']),
+            new \Twig_SimpleFilter('hashids_decode', [$this, 'decode']),
+        ];
+    }
+
+    public function getName()
+    {
+        return 'hashids_extension';
+    }
+
+    public function encode($number)
+    {
+        return $this->hashids->encode($number);
+    }
+
+    public function decode($hash)
+    {
+        return $this->hashids->decode($hash);
+    }
+
+}

--- a/src/Twig/HashidsExtension.php
+++ b/src/Twig/HashidsExtension.php
@@ -7,7 +7,7 @@ use Roukmoute\HashidsBundle\Hashids;
 class HashidsExtension extends \Twig_Extension
 {
     /**
-     * @var \Hashids\Hashids;
+     * @var Hashids
      */
     private $hashids;
 
@@ -15,6 +15,7 @@ class HashidsExtension extends \Twig_Extension
     {
         $this->hashids = $hashids;
     }
+
     public function getFilters()
     {
         return [


### PR DESCRIPTION
Since I use hashids quite often to generate paths in twig templates, I thought it would be a good idea to add a twig extension.