### PR TITLE
Require doctrine common instead of bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "doctrine/doctrine-bundle": "^1.8",
+    "doctrine/common": "^2.8",
     "hashids/hashids": "^2.0",
     "sensio/framework-extra-bundle": "^3.0",
     "symfony/http-kernel": "^3.3"


### PR DESCRIPTION
Or, we can put this in the suggest and say "Need doctrine/common to use the ParamConverter". 
And maybe do something smart in our bundle extension