### PR TITLE
Loosened symfony/http--kernel version restriction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "doctrine/orm": "^2.6",
     "hashids/hashids": "^2.0",
     "sensio/framework-extra-bundle": "^3.0",
-    "symfony/http-kernel": "^3.3"
+    "symfony/http-kernel": "~3.3|~4.0"
   },
   "require-dev": {
     "bossa/phpspec2-expect": "^3.0",


### PR DESCRIPTION
The current restriction to "~3.3" forces apps which use symfony 4 to downgrade the kernel needlessly. I am not aware of incompatibilities between versions 3 and 4 of the kernel.