### PR TITLE
Use Hashids\HashidsInterface as alias to hashids service in order to allow autowiring

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,9 @@
             <argument>%hashids.min_hash_length%</argument>
             <argument>%hashids.alphabet%</argument>
         </service>
-
+        
+        <service id="Hashids\HashidsInterface" alias="hashids" public="false" />
+        
         <service id="hashids.converter"
                  class="Roukmoute\HashidsBundle\ParamConverter\HashidsParamConverter"
         >


### PR DESCRIPTION
Adding ` Hashids\HashidsInterface` alias allow to fetch hashids in constructor  and controllers methods

```
class EncodeController
{
    public function encodeAction(\Hashids\HashidsInterface $hashids, $value)
    {
        return $hashids->encode($value);
    }
}
```
OR
```
class EncodeController
{
    public function __construct(\Hashids\HashidsInterface $hashids)
    {
        $this->hashids = $hashids;
    }

    public function encodeAction($value)
    {
        return $this->hashids->encode($value);
    }
}

```
