### PR TITLE
Fixed configuration loading, deprecated since Symfony 4.2.

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): NodeParentInterface
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('roukmoute_hashids');
+        $treeBuilder = new TreeBuilder('roukmoute_hashids');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
Since Symfony 4.2, [the configuration root node name must be passed as argument when creating an instance of `TreeBuilder`](https://symfony.com/doc/current/components/config/definition.html#defining-a-hierarchy-of-configuration-values-using-the-treebuilder).